### PR TITLE
Configure api url for web interface

### DIFF
--- a/web/app/api/chat/history/route.ts
+++ b/web/app/api/chat/history/route.ts
@@ -1,4 +1,4 @@
-const serverBase = process.env.PY_SERVER_URL || 'http://localhost:8001';
+const serverBase = process.env.PY_SERVER_URL || 'https://openpoke.onrender.com';
 const historyPath = `${serverBase.replace(/\/$/, '')}/api/v1/chat/history`;
 
 async function forward(method: 'GET' | 'DELETE') {

--- a/web/app/api/chat/route.ts
+++ b/web/app/api/chat/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: Request) {
     return new Response('Missing messages', { status: 400 });
   }
 
-  const serverBase = process.env.PY_SERVER_URL || 'http://localhost:8001';
+  const serverBase = process.env.PY_SERVER_URL || 'https://openpoke.onrender.com';
   const serverPath = process.env.PY_CHAT_PATH || '/api/v1/chat/send';
   const url = `${serverBase.replace(/\/$/, '')}${serverPath}`;
 

--- a/web/app/api/gmail/connect/route.ts
+++ b/web/app/api/gmail/connect/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
   const userId = body?.userId || '';
   const authConfigId = body?.authConfigId || '';
 
-  const serverBase = process.env.PY_SERVER_URL || 'http://localhost:8001';
+  const serverBase = process.env.PY_SERVER_URL || 'https://openpoke.onrender.com';
   const url = `${serverBase.replace(/\/$/, '')}/api/v1/gmail/connect`;
 
   try {

--- a/web/app/api/gmail/disconnect/route.ts
+++ b/web/app/api/gmail/disconnect/route.ts
@@ -10,7 +10,7 @@ export async function POST(req: Request) {
   const connectionId = body?.connectionId || '';
   const connectionRequestId = body?.connectionRequestId || '';
 
-  const serverBase = process.env.PY_SERVER_URL || 'http://localhost:8001';
+  const serverBase = process.env.PY_SERVER_URL || 'https://openpoke.onrender.com';
   const url = `${serverBase.replace(/\/$/, '')}/api/v1/gmail/disconnect`;
   const payload: any = {};
   if (userId) payload.user_id = userId;

--- a/web/app/api/gmail/status/route.ts
+++ b/web/app/api/gmail/status/route.ts
@@ -8,7 +8,7 @@ export async function POST(req: Request) {
   const userId = body?.userId || '';
   const connectionRequestId = body?.connectionRequestId || '';
 
-  const serverBase = process.env.PY_SERVER_URL || 'http://localhost:8001';
+  const serverBase = process.env.PY_SERVER_URL || 'https://openpoke.onrender.com';
   const url = `${serverBase.replace(/\/$/, '')}/api/v1/gmail/status`;
   const payload: any = {};
   if (userId) payload.user_id = userId;

--- a/web/app/api/timezone/route.ts
+++ b/web/app/api/timezone/route.ts
@@ -13,7 +13,7 @@ export async function POST(req: Request) {
     return new Response('Missing or invalid timezone', { status: 400 });
   }
 
-  const serverBase = process.env.PY_SERVER_URL || 'http://localhost:8001';
+  const serverBase = process.env.PY_SERVER_URL || 'https://openpoke.onrender.com';
   const url = `${serverBase.replace(/\/$/, '')}/api/v1/meta/timezone`;
 
   try {


### PR DESCRIPTION
Update default API server URL to `https://openpoke.onrender.com` to support remote web interface deployment.

The web interface now defaults to the specified production URL when `PY_SERVER_URL` is not set, allowing it to connect to the API server when running on a different machine.

---
<a href="https://cursor.com/background-agent?bcId=bc-7890b689-22e5-41c2-9091-27bc129482c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-7890b689-22e5-41c2-9091-27bc129482c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

